### PR TITLE
Fix build error

### DIFF
--- a/src/Parser.cpp
+++ b/src/Parser.cpp
@@ -294,7 +294,7 @@ Parser::~Parser() {
 
 // Return the entire contents of the file at the given path.
 std::string Parser::read_file(const std::string &path) {
-    std::ifstream t(path);
+    std::ifstream t(path.c_str());
     if (!t.is_open()) {
         std::string msg = "Failed to open file at " + path;
         abort(msg);


### PR DESCRIPTION
g++  -c src/Parser.cpp -o obj/Parser.o -MMD -MF obj/Parser.d -MT obj/Parser.o
src/Parser.cpp: In member function ‘std::string Bish::Parser::read_file(const string&)’:
src/Parser.cpp:297:25: error: no matching function for call to ‘std::basic_ifstream<char>::basic_ifstream(const string&)’
     std::ifstream t(path);
