### PR TITLE
Add shebang capability

### DIFF
--- a/src/bish.cpp
+++ b/src/bish.cpp
@@ -98,6 +98,11 @@ int main(int argc, char **argv) {
     }
 
     if (strcmp(argv[1], "-r") == 0) {
+        if (argc != 3) {
+            std::cerr << "-r needs a filename\n";
+            return 1;
+        }
+
         std::string path(argv[2]);
         Bish::Parser p;
         Bish::Module *m = p.parse(path);

--- a/src/bish.cpp
+++ b/src/bish.cpp
@@ -80,7 +80,7 @@ void run_on_bash(std::istream &is) {
     FILE *bash = popen("bash", "w");
     char buf[4096];
     int n;
-    while (n = is.readsome(buf, sizeof(buf))) {
+    while ((n = is.readsome(buf, sizeof(buf)))) {
         fwrite(buf, 1, n, bash);
     }
 

--- a/src/bish.cpp
+++ b/src/bish.cpp
@@ -79,10 +79,11 @@ void compile_to_bash(std::ostream &os, Bish::Module *m) {
 void run_on_bash(std::istream &is) {
     FILE *bash = popen("bash", "w");
     char buf[4096];
-    while (is.read(buf, sizeof(buf))) {
+
+    do {
+        is.read(buf, sizeof(buf));
         fwrite(buf, 1, is.gcount(), bash);
-    }
-    fwrite(buf, 1, is.gcount(), bash);
+    } while (is.gcount() > 0);
 
     fflush(bash);
     pclose(bash);

--- a/src/bish.cpp
+++ b/src/bish.cpp
@@ -89,8 +89,10 @@ void run_on_bash(std::istream &is) {
 
 int main(int argc, char **argv) {
     if (argc < 2) {
-        std::cerr << "USAGE: " << argv[0] << " <INPUT>\n";
+        std::cerr << "USAGE: " << argv[0] << " [-r] <INPUT>\n";
         std::cerr << "  Compiles Bish file <INPUT> to bash.\n";
+        std::cerr << "\nOPTIONS:\n";
+        std::cerr << "  -r  compiles and runs the file.\n";
         return 1;
     }
 

--- a/src/bish.cpp
+++ b/src/bish.cpp
@@ -79,11 +79,12 @@ void compile_to_bash(std::ostream &os, Bish::Module *m) {
 void run_on_bash(std::istream &is) {
     FILE *bash = popen("bash", "w");
     char buf[4096];
-    while (is) {
-        is.read(buf, sizeof(buf));
-        fwrite(buf, 1, sizeof(buf), bash);
+    int n;
+    while (n = is.readsome(buf, sizeof(buf))) {
+        fwrite(buf, 1, n, bash);
     }
 
+    fflush(bash);
     pclose(bash);
 }
 

--- a/src/bish.cpp
+++ b/src/bish.cpp
@@ -79,10 +79,10 @@ void compile_to_bash(std::ostream &os, Bish::Module *m) {
 void run_on_bash(std::istream &is) {
     FILE *bash = popen("bash", "w");
     char buf[4096];
-    int n;
-    while ((n = is.readsome(buf, sizeof(buf)))) {
-        fwrite(buf, 1, n, bash);
+    while (is.read(buf, sizeof(buf))) {
+        fwrite(buf, 1, is.gcount(), bash);
     }
+    fwrite(buf, 1, is.gcount(), bash);
 
     fflush(bash);
     pclose(bash);


### PR DESCRIPTION
This pull request adds a new flag (-r) that can be used to directly execute a bish file

Either add -r before the filename

```
$ bish -r examples/fib.bish
```

or add

```
#!/bin/bish -r
```

to the top of the file

This would close #7 (Unless @reklis wanted a full REPL, but I don't think that was the intent)
