### PR TITLE
Add empty function

### DIFF
--- a/src/StdLib.bish
+++ b/src/StdLib.bish
@@ -33,3 +33,12 @@ def cd(path) {
 def cwd() {
     return @(pwd);
 }
+
+# Check for empty string.
+def empty(s) {
+    if (@(expr length "$s") > 0) {
+        return false;
+    } else {
+        return true;
+    }
+}


### PR DESCRIPTION
Like the project.

While this is my small contribution. To check the string length standard means you can not use the expression `${#myVar}`.
