### PR TITLE
missing #include in file:

### DIFF
--- a/src/Compile.cpp
+++ b/src/Compile.cpp
@@ -1,5 +1,6 @@
 #include <limits.h>
 #include <cassert>
+#include <cstdlib>
 #include "CodeGen_Bash.h"
 #include "Compile.h"
 #include "Config.h"


### PR DESCRIPTION
- #include <cstdlib> in compile.cpp

without it, the code does not compile on my machine: gcc version 4.6.3 (Ubuntu/Linaro 4.6.3-1ubuntu5)
