### PR TITLE
Include the generated dependency files

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -17,6 +17,8 @@ CONFIG_CONSTANTS = -DSTDLIB_PATH="\"$(ROOT_DIR)/src/StdLib.bish\""
 
 all: bish
 
+-include $(OBJ)/*.d
+
 $(OBJ)/%.o: $(SRC)/%.cpp $(SRC)/%.h
 	@-mkdir -p $(OBJ)
 	$(CXX) $(CXXFLAGS) -c $< -o $@ -MMD -MF $(OBJ)/$*.d -MT $(OBJ)/$*.o $(CONFIG_CONSTANTS)


### PR DESCRIPTION
Prior to this change, `touch src/Parser.h` would only cause Parser.o to
recompile, but Compile.cpp should also have been recompiled since it
includes Parser.h. The deps were created, just not included in the
Makefile.
