### PR TITLE
Return with the exit status of a run file.

### DIFF
--- a/src/bish.cpp
+++ b/src/bish.cpp
@@ -20,7 +20,9 @@ int run_on_bash(std::istream &is) {
 
     fflush(bash);
 
-    int e = pclose(bash)/256;
+    // pclose returns the exit status of the process,
+    // but shifted to the left by 8 bits.
+    int e = pclose(bash) >> 8;
     return e;
 }
 

--- a/src/bish.cpp
+++ b/src/bish.cpp
@@ -63,8 +63,7 @@ int main(int argc, char **argv) {
     std::stringstream s;
     Bish::compile_to_bash(run_after_compile ? s : std::cout, m);
     if (run_after_compile) {
-        int exit_status = 0;
-        exit_status = run_on_bash(s);
+        int exit_status = run_on_bash(s);
         exit(exit_status);
     }
 

--- a/src/bish.cpp
+++ b/src/bish.cpp
@@ -9,7 +9,7 @@
 #include "Compile.h"
 #include "Parser.h"
 
-void run_on_bash(std::istream &is) {
+int run_on_bash(std::istream &is) {
     FILE *bash = popen("bash", "w");
     char buf[4096];
 
@@ -19,7 +19,9 @@ void run_on_bash(std::istream &is) {
     } while (is.gcount() > 0);
 
     fflush(bash);
-    pclose(bash);
+
+    int e = pclose(bash)/256;
+    return e;
 }
 
 void usage(char *argv0) {
@@ -59,7 +61,9 @@ int main(int argc, char **argv) {
     std::stringstream s;
     Bish::compile_to_bash(run_after_compile ? s : std::cout, m);
     if (run_after_compile) {
-        run_on_bash(s);
+        int exit_status = 0;
+        exit_status = run_on_bash(s);
+        exit(exit_status);
     }
 
     return 0;


### PR DESCRIPTION
When a file is run with `./bish -r file.bish` it returns with the exit status of file.bish.
Closes #39
