### PR TITLE
Add missing header

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,3 @@
 obj
 *.dSYM
+bish

--- a/src/Errors.h
+++ b/src/Errors.h
@@ -1,6 +1,7 @@
 #ifndef __BISH_ERRORS_H__
 #define __BISH_ERRORS_H__
 
+#include <cstdlib>
 #include <iostream>
 #include <string>
 #include <sstream>


### PR DESCRIPTION
Really simple PR. Errors.h references 'abort' which is part of cstdlib but wasn't included explicitly causing this failure on Ubuntu 14.10:

```
In file included from src/TypeChecker.cpp:3:0:
src/Errors.h: In destructor ‘Bish::ErrorReport::~ErrorReport()’:
src/Errors.h:21:19: error: ‘abort’ was not declared in this scope
             abort();
                   ^
Makefile:23: recipe for target 'obj/TypeChecker.o' failed
make: *** [obj/TypeChecker.o] Error 1
```

Other commit is just a suggestion.
