### PR TITLE
Exit with 0 when executing with -h argument

### DIFF
--- a/src/bish.cpp
+++ b/src/bish.cpp
@@ -62,7 +62,7 @@ int main(int argc, char **argv) {
         switch (c) {
         case 'h':
             usage(argv[0]);
-            return 1;
+            return 0;
         case 'r':
             run_after_compile = true;
             break;


### PR DESCRIPTION
Should `bish -h` really exit with code 1? I mean, I asked for the usage information, it printed it out, so we have a success, right? 
This also allows me to successfully test the brew formulae. :grinning: 
