### PR TITLE
Minor makefile changes

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,5 +1,5 @@
 CXX?=c++
-CXXFLAGS?=-g -O0
+CXXFLAGS?=-g -O0 -pipe -Wall -Wextra -Wno-reorder
 RM=rm -f
 
 SRC=src
@@ -26,8 +26,7 @@ $(OBJ)/%.o: $(SRC)/%.cpp $(SRC)/%.h
 
 $(OBJ)/libbish.a: $(OBJECTS)
 	$(LD) -r -o $(OBJ)/bish.o $(OBJECTS)
-	ar -ru $@ $(OBJ)/bish.o
-	ranlib $@
+	ar -rsu $@ $(OBJ)/bish.o
 
 bish: $(SRC)/bish.cpp $(OBJ)/libbish.a
 	$(CXX) $(CXXFLAGS) -o bish $(SRC)/bish.cpp $(OBJ)/libbish.a $(CONFIG_CONSTANTS)


### PR DESCRIPTION
* ranlib is a thing of the past, and all major ar implementations have -s to do it while it makes the archive. the extra invocation takes plenty of time on my Cygwin.
* -pipe tells gcc to use memory instead of temp files. less IO means faster build.
* the warnings are there just there to make things safer. -Wreorder seems to complain a lot, but since most member initializers are pure it feels okay to turn it off.